### PR TITLE
Adding github action to create formatted R package source in a dedicated branch on every release / merge to main

### DIFF
--- a/.github/workflows/r-cran-branch.yml
+++ b/.github/workflows/r-cran-branch.yml
@@ -1,0 +1,46 @@
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  release:
+    types: [published]
+  workflow_dispatch:
+
+name: Update R Package Dev Branch
+
+jobs:
+  testing:
+    name: r-cran-branch
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+    permissions:
+      contents: write
+    
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: 'recursive'
+
+      - uses: r-lib/actions/setup-pandoc@v2
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::testthat, any::decor
+
+      - name: Create CRAN-formatted source package in stochtree_cran subfolder
+        run: |
+          Rscript cran-bootstrap.R
+      
+      - name: Deploy to CRAN dev branch
+        if: github.event_name != 'pull_request'
+        uses: JamesIves/github-pages-deploy-action@v4.5.0
+        with:
+          clean: false
+          branch: r-dev
+          folder: stochtree_cran

--- a/cran-bootstrap.R
+++ b/cran-bootstrap.R
@@ -23,7 +23,7 @@ if (!dir.exists(cran_dir)) {
 }
 
 # Copy the "core" package files to CRAN folder
-src_files <- list.files("src", recursive = TRUE, full.names = TRUE)
+src_files <- list.files("src", pattern = ".[^o]$", recursive = TRUE, full.names = TRUE)
 pybind_src_files <- list.files("src", pattern = "^(py_)", recursive = TRUE, full.names = TRUE)
 r_src_files <- src_files[!(src_files %in% pybind_src_files)]
 pkg_core_files <- c(
@@ -35,7 +35,7 @@ pkg_core_files <- c(
     "NAMESPACE",
     list.files("R", recursive = TRUE, full.names = TRUE),
     r_src_files, 
-    list.files("vignettes", recursive = TRUE, full.names = TRUE)
+    list.files("vignettes", pattern = ".(Rmd|bib)$", recursive = TRUE, full.names = TRUE)
 )
 pkg_core_files_dst <- file.path(cran_dir, pkg_core_files)
 # Handle tests separately (move from test/R/ folder to tests/ folder)


### PR DESCRIPTION
General idea is to provide a simple workflow for installing the latest development version of the package through `remotes::install_github`.